### PR TITLE
Adds Solr, Memcached and ES at Java Sample code

### DIFF
--- a/java/.platform.app.yaml
+++ b/java/.platform.app.yaml
@@ -4,13 +4,16 @@ type: "java:8"
 disk: 1024
 
 hooks:
-  build: mvn clean install
+  build: mvn clean install -U
 
 relationships:
   database: 'mysql:mysql'
   postgresql: 'postgresql:postgresql'
   mongodb: 'mongodb:mongodb'
   redis: 'redis:redis'
+  elasticsearch: 'elasticsearch:elasticsearch'
+  memcached: 'memcached:memcached'
+  solr: 'solr:solr'
 
 web:
   commands:

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -14,7 +14,6 @@
         <version>2.1.5.RELEASE</version>
     </parent>
 
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-javadoc-plugin.vesion>3.0.1</maven-javadoc-plugin.vesion>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -27,6 +27,7 @@
         <mongo.version>3.8.2</mongo.version>
         <mysql.version>8.0.16</mysql.version>
         <postgresql.version>42.2.5</postgresql.version>
+        <elasticsearch.version>6.7.1</elasticsearch.version>
     </properties>
 
     <dependencies>
@@ -59,7 +60,21 @@
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
+            <version>${elasticsearch.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.spy</groupId>
+            <artifactId>spymemcached</artifactId>
+            <version>2.12.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.solr</groupId>
+            <artifactId>solr-solrj</artifactId>
+            <version>8.1.1</version>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>

--- a/java/src/main/java/sh/platform/languages/SampleCodeType.java
+++ b/java/src/main/java/sh/platform/languages/SampleCodeType.java
@@ -1,10 +1,13 @@
 package sh.platform.languages;
 
 import com.google.gson.Gson;
+import sh.platform.languages.sample.ElasticsearchSample;
+import sh.platform.languages.sample.MemcachedSample;
 import sh.platform.languages.sample.MongoDBSample;
 import sh.platform.languages.sample.MySQLSample;
 import sh.platform.languages.sample.PostgreSQLSample;
 import sh.platform.languages.sample.RedisSample;
+import sh.platform.languages.sample.SolrSample;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -17,7 +20,10 @@ public enum SampleCodeType {
     MONGODB(new MongoDBSample(), "MongoDB"),
     MYSQL(new MySQLSample(), "MySQL"),
     POSTGRESQL(new PostgreSQLSample(), "PostgreSQL"),
-    REDIS(new RedisSample(), "Redis");
+    REDIS(new RedisSample(), "Redis"),
+    MEMCACHED(new MemcachedSample(), "Memcached"),
+    ELASTICSEARCH(new ElasticsearchSample(), "Elasticsearch"),
+    SORL(new SolrSample(), "Sorl");
 
     private final Supplier<String> demoClass;
     private final String label;

--- a/java/src/main/java/sh/platform/languages/SampleCodeType.java
+++ b/java/src/main/java/sh/platform/languages/SampleCodeType.java
@@ -23,7 +23,7 @@ public enum SampleCodeType {
     REDIS(new RedisSample(), "Redis"),
     MEMCACHED(new MemcachedSample(), "Memcached"),
     ELASTICSEARCH(new ElasticsearchSample(), "Elasticsearch"),
-    SORL(new SolrSample(), "Sorl");
+    SOLR(new SolrSample(), "Solr");
 
     private final Supplier<String> demoClass;
     private final String label;

--- a/java/src/main/java/sh/platform/languages/SampleResource.java
+++ b/java/src/main/java/sh/platform/languages/SampleResource.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -51,9 +53,13 @@ public class SampleResource {
                 headers.setContentType(MediaType.TEXT_PLAIN);
                 return new ResponseEntity<>(message, headers, HttpStatus.OK);
             } catch (Exception exp) {
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                exp.printStackTrace(pw);
                 HttpHeaders headers = new HttpHeaders();
                 headers.setContentType(MediaType.TEXT_PLAIN);
-                return new ResponseEntity<>(exp.getMessage(), headers, HttpStatus.INTERNAL_SERVER_ERROR);
+                final String message = sw.toString();
+                return new ResponseEntity<>(message, headers, HttpStatus.INTERNAL_SERVER_ERROR);
             }
         }
         return notFound();

--- a/java/src/main/java/sh/platform/languages/sample/ElasticsearchSample.java
+++ b/java/src/main/java/sh/platform/languages/sample/ElasticsearchSample.java
@@ -48,7 +48,7 @@ public class ElasticsearchSample implements Supplier<String> {
                 Map<String, Object> jsonMap = new HashMap<>();
                 jsonMap.put("name", animal);
                 jsonMap.put("age", current().nextInt(1, 10));
-                jsonMap.put("is cute?", current().nextBoolean());
+                jsonMap.put("is_cute", current().nextBoolean());
 
                 IndexRequest indexRequest = new IndexRequest(index, type)
                         .id(animal).source(jsonMap);

--- a/java/src/main/java/sh/platform/languages/sample/ElasticsearchSample.java
+++ b/java/src/main/java/sh/platform/languages/sample/ElasticsearchSample.java
@@ -1,0 +1,87 @@
+package sh.platform.languages.sample;
+
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import sh.platform.config.Config;
+import sh.platform.config.Elasticsearch;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static java.util.concurrent.ThreadLocalRandom.current;
+
+public class ElasticsearchSample implements Supplier<String> {
+
+    @Override
+    public String get() {
+        StringBuilder logger = new StringBuilder();
+
+        // Create a new config object to ease reading the Platform.sh environment variables.
+        // You can alternatively use getenv() yourself.
+        Config config = new Config();
+
+        Elasticsearch elasticsearch = config.getCredential("elasticsearch", Elasticsearch::new);
+
+        // Create an Elasticsearch client object.
+        RestHighLevelClient client = elasticsearch.get();
+
+        try {
+
+            String index = "animals";
+            String type = "mammals";
+            // Index a few document.
+            final List<String> animals = Arrays.asList("dog", "cat", "monkey", "horse");
+            for (String animal : animals) {
+                Map<String, Object> jsonMap = new HashMap<>();
+                jsonMap.put("name", animal);
+                jsonMap.put("age", current().nextInt(1, 10));
+                jsonMap.put("is cute?", current().nextBoolean());
+
+                IndexRequest indexRequest = new IndexRequest(index, type)
+                        .id(animal).source(jsonMap);
+                client.index(indexRequest, RequestOptions.DEFAULT);
+            }
+
+            RefreshRequest refresh = new RefreshRequest(index);
+
+            // Force just-added items to be indexed
+            RefreshResponse refreshResponse = client.indices().refresh(refresh, RequestOptions.DEFAULT);
+
+            // Search for documents.
+            SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+            sourceBuilder.query(QueryBuilders.termQuery("name", "dog"));
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices(index);
+            searchRequest.source(sourceBuilder);
+
+            SearchResponse search = client.search(searchRequest, RequestOptions.DEFAULT);
+
+            for (SearchHit hit : search.getHits()) {
+                String id = hit.getId();
+                final Map<String, Object> source = hit.getSourceAsMap();
+                logger.append(String.format("result id %s source: %s", id, source)).append('\n');
+            }
+
+            // Delete documents.
+            for (String animal : animals) {
+                client.delete(new DeleteRequest(index, type, animal), RequestOptions.DEFAULT);
+            }
+        } catch (IOException exp) {
+            throw new RuntimeException("An error when execute Elasticsearch: " + exp.getMessage());
+        }
+        return logger.toString();
+    }
+}

--- a/java/src/main/java/sh/platform/languages/sample/MemcachedSample.java
+++ b/java/src/main/java/sh/platform/languages/sample/MemcachedSample.java
@@ -1,0 +1,38 @@
+package sh.platform.languages.sample;
+
+import net.spy.memcached.MemcachedClient;
+import sh.platform.config.Config;
+
+import java.util.function.Supplier;
+
+import sh.platform.config.Memcached;
+
+public class MemcachedSample implements Supplier<String> {
+
+    @Override
+    public String get() {
+        StringBuilder logger = new StringBuilder();
+
+        // Create a new config object to ease reading the Platform.sh environment variables.
+        // You can alternatively use getenv() yourself.
+        Config config = new Config();
+
+        // Get the credentials to connect to the Memcached service.
+        Memcached memcached = config.getCredential("memcached", Memcached::new);
+
+        final MemcachedClient client = memcached.get();
+
+        String key = "cloud";
+        String value = "platformsh";
+
+        // Set a value.
+        client.set(key, 0, value);
+
+        // Read it back.
+        Object test = client.get(key);
+
+        logger.append(String.format("Found value %s for key %s.", test, key));
+
+        return logger.toString();
+    }
+}

--- a/java/src/main/java/sh/platform/languages/sample/SolrSample.java
+++ b/java/src/main/java/sh/platform/languages/sample/SolrSample.java
@@ -48,7 +48,7 @@ public class SolrSample implements Supplier<String> {
             QueryResponse queryResponse = solrClient.query(query);
 
             SolrDocumentList results = queryResponse.getResults();
-            logger.append(String.format("Selecting documents (1 expected):  %s \n", results.getNumFound()));
+            logger.append(String.format("Selecting documents (1 expected):  %s \n", results.getNumFound())).append('\n');
 
             // Delete one document
             solrClient.deleteById(id);
@@ -56,7 +56,7 @@ public class SolrSample implements Supplier<String> {
 
             query.set("q", "city:London");
             queryResponse = solrClient.query(query);
-            String.format("Deleting one document. Status (0 is success):  %s \n", results.getNumFound());
+            logger.append(String.format("Deleting one document. Status (0 is success):  %s \n", results.getNumFound()));
         } catch (SolrServerException | IOException exp) {
             throw new RuntimeException("An error when execute Sorl: " + exp.getMessage());
         }

--- a/java/src/main/java/sh/platform/languages/sample/SolrSample.java
+++ b/java/src/main/java/sh/platform/languages/sample/SolrSample.java
@@ -48,7 +48,7 @@ public class SolrSample implements Supplier<String> {
             QueryResponse queryResponse = solrClient.query(query);
 
             SolrDocumentList results = queryResponse.getResults();
-            logger.append(String.format("Selecting documents (1 expected):  %s \n", results.getNumFound())).append('\n');
+            logger.append(String.format("Selecting documents (1 expected):  %d \n", results.getNumFound()));
 
             // Delete one document
             solrClient.deleteById(id);

--- a/java/src/main/java/sh/platform/languages/sample/SolrSample.java
+++ b/java/src/main/java/sh/platform/languages/sample/SolrSample.java
@@ -1,0 +1,66 @@
+package sh.platform.languages.sample;
+
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.impl.XMLResponseParser;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.UpdateResponse;
+import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.SolrInputDocument;
+import sh.platform.config.Config;
+import sh.platform.config.Solr;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+public class SolrSample implements Supplier<String> {
+
+    @Override
+    public String get() {
+
+        StringBuilder logger = new StringBuilder();
+
+        // Create a new config object to ease reading the Platform.sh environment variables.
+        // You can alternatively use getenv() yourself.
+        Config config = new Config();
+
+        Solr sorl = config.getCredential("solr", Solr::new);
+
+        try {
+
+            final HttpSolrClient solrClient = sorl.get();
+            solrClient.setParser(new XMLResponseParser());
+
+            // Add a document
+            SolrInputDocument document = new SolrInputDocument();
+            final String id = "123456";
+            document.addField("id", id);
+            document.addField("name", "Ada Lovelace");
+            document.addField("city", "London");
+            solrClient.add(document);
+            final UpdateResponse response = solrClient.commit();
+            logger.append("Adding one document. Status (0 is success): ")
+                    .append(response.getStatus()).append('\n');
+
+            SolrQuery query = new SolrQuery();
+            query.set("q", "city:London");
+            QueryResponse queryResponse = solrClient.query(query);
+
+            SolrDocumentList results = queryResponse.getResults();
+            logger.append(String.format("Selecting documents (1 expected):  %s \n", results.getNumFound()));
+
+            // Delete one document
+            solrClient.deleteById(id);
+            solrClient.commit();
+
+            query.set("q", "city:London");
+            queryResponse = solrClient.query(query);
+            String.format("Deleting one document. Status (0 is success):  %s \n", results.getNumFound());
+        } catch (SolrServerException | IOException exp) {
+            throw new RuntimeException("An error when execute Sorl: " + exp.getMessage());
+        }
+
+        return logger.toString();
+    }
+}

--- a/java/src/main/java/sh/platform/languages/sample/SolrSample.java
+++ b/java/src/main/java/sh/platform/languages/sample/SolrSample.java
@@ -25,11 +25,11 @@ public class SolrSample implements Supplier<String> {
         // You can alternatively use getenv() yourself.
         Config config = new Config();
 
-        Solr sorl = config.getCredential("solr", Solr::new);
+        Solr solr = config.getCredential("solr", Solr::new);
 
         try {
 
-            final HttpSolrClient solrClient = sorl.get();
+            final HttpSolrClient solrClient = solr.get();
             solrClient.setParser(new XMLResponseParser());
 
             // Add a document
@@ -52,13 +52,11 @@ public class SolrSample implements Supplier<String> {
 
             // Delete one document
             solrClient.deleteById(id);
-            solrClient.commit();
 
-            query.set("q", "city:London");
-            queryResponse = solrClient.query(query);
-            logger.append(String.format("Deleting one document. Status (0 is success):  %s \n", results.getNumFound()));
+            logger.append(String.format("Deleting one document. Status (0 is success):  %s \n",
+                    solrClient.commit().getStatus()));
         } catch (SolrServerException | IOException exp) {
-            throw new RuntimeException("An error when execute Sorl: " + exp.getMessage());
+            throw new RuntimeException("An error when execute Solr: " + exp.getMessage());
         }
 
         return logger.toString();


### PR DESCRIPTION
I could make the code running here:

https://github.com/otaviojava/java-language-example

## Source code

* [List services](https://master-7rqtwti-5ie6orm4mur2i.eu-3.platformsh.site/java/)
* [ES](https://master-7rqtwti-5ie6orm4mur2i.eu-3.platformsh.site/java/elasticsearch/)
* [Memcached](https://master-7rqtwti-5ie6orm4mur2i.eu-3.platformsh.site/java/memcached/)
* [Solr](https://master-7rqtwti-5ie6orm4mur2i.eu-3.platformsh.site/java/solr/)

## Output

* [ES](https://master-7rqtwti-5ie6orm4mur2i.eu-3.platformsh.site/java/elasticsearch/output)
* [Memcached](https://master-7rqtwti-5ie6orm4mur2i.eu-3.platformsh.site/java/memcached/output)
* [Solr](https://master-7rqtwti-5ie6orm4mur2i.eu-3.platformsh.site/java/solr/output)

## Improves the log error

This PR also has an improvement to add the whole stack trace in the error message. It is really useful when something goes wrong in the Java world. 


## What is not included

The status with HTML is not at this PR, I'll create a new PR specific to it, because, I think the discussion around it will take a long time.