### PR TITLE
Match the documentation naming

### DIFF
--- a/golang/examples/mongodb.go
+++ b/golang/examples/mongodb.go
@@ -3,12 +3,13 @@ package examples
 import (
 	"context"
 	"fmt"
+	"time"
+
 	psh "github.com/platformsh/config-reader-go/v2"
 	mongoPsh "github.com/platformsh/config-reader-go/v2/mongo"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"time"
 )
 
 func UsageExampleMongoDB() string {
@@ -18,8 +19,10 @@ func UsageExampleMongoDB() string {
 	config, err := psh.NewRuntimeConfig()
 	checkErr(err)
 
-	// Get the credentials to connect to the Solr service.
-	credentials, err := config.Credentials("mongodb")
+	// Get the credentials to connect to the mongodb service.
+	// The 'database' relationship is generally the name of primary database of an application.
+	// It could be anything, though, as in the case here here where it's called "database".
+	credentials, err := config.Credentials("database")
 	checkErr(err)
 
 	// Retrieve the formatted credentials for mongo-driver.

--- a/java/src/main/java/sh/platform/languages/sample/MongoDBSample.java
+++ b/java/src/main/java/sh/platform/languages/sample/MongoDBSample.java
@@ -22,8 +22,8 @@ public class MongoDBSample implements Supplier<String> {
         Config config = new Config();
 
         // The 'database' relationship is generally the name of primary database of an application.
-        // It could be anything, though, as in the case here here where it's called "mongodb".
-        MongoDB database = config.getCredential("mongodb", MongoDB::new);
+        // It could be anything, though, as in the case here here where it's called "database".
+        MongoDB database = config.getCredential("database", MongoDB::new);
         MongoClient mongoClient = database.get();
         final MongoDatabase mongoDatabase = mongoClient.getDatabase(database.getDatabase());
         MongoCollection<Document> collection = mongoDatabase.getCollection("scientist");

--- a/nodejs/examples/mongodb.js
+++ b/nodejs/examples/mongodb.js
@@ -2,10 +2,12 @@ const mongodb = require('mongodb');
 const config = require("platformsh-config").config();
 
 exports.usageExample = async function() {
-    const credentials = config.credentials('mongodb');
+    // The 'database' relationship is generally the name of primary database of an application.
+    // It could be anything, though, as in the case here here where it's called "database".
+    const credentials = config.credentials('database');
     const MongoClient = mongodb.MongoClient;
 
-    var client = await MongoClient.connect(config.formattedCredentials('mongodb', 'mongodb'));
+    var client = await MongoClient.connect(config.formattedCredentials('database', 'mongodb'));
 
     let db = client.db(credentials["path"]);
 

--- a/php/examples/MongoDB.php
+++ b/php/examples/MongoDB.php
@@ -10,8 +10,8 @@ use MongoDB\Client;
 $config = new Config();
 
 // The 'database' relationship is generally the name of primary database of an application.
-// It could be anything, though, as in the case here here where it's called "mongodb".
-$credentials = $config->credentials('mongodb');
+// It could be anything, though, as in the case here here where it's called "database".
+$credentials = $config->credentials('database');
 
 try {
 

--- a/python/examples/mongodb.py
+++ b/python/examples/mongodb.py
@@ -9,11 +9,11 @@ def usage_example():
     config = Config()
 
     # The 'database' relationship is generally the name of primary SQL database of an application.
-    # It could be anything, though, as in the case here here where it's called "mongodb".
-    credentials = config.credentials('mongodb')
+    # It could be anything, though, as in the case here here where it's called "database".
+    credentials = config.credentials('database')
 
     try:
-        formatted = config.formatted_credentials('mongodb', 'pymongo')
+        formatted = config.formatted_credentials('database', 'pymongo')
 
         server = '{0}://{1}:{2}@{3}'.format(
             credentials['scheme'],


### PR DESCRIPTION
The idea is to match the relationships in https://docs.platform.sh/configuration/services/mongodb.html because I think it's not cristal clear for the user. Maybe we can just change the relationship name on the mongodb documentation page, but an other name than mongodb which I think is confusing.