### PR TITLE
Node.js refactor

### DIFF
--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -34,8 +34,8 @@ rabbitmq38:
 redis6:
     type: redis:6.0
     size: S
-solr84:
-    type: solr:8.4
+solr86:
+    type: solr:8.6
     disk: 256
     size: S
     configuration:

--- a/golang/.platform.app.yaml
+++ b/golang/.platform.app.yaml
@@ -24,7 +24,7 @@ hooks:
 relationships:
     database: 'mariadb104:mysql'
     postgresql: 'postgresql12:postgresql'
-    solr: 'solr84:solr'
+    solr: 'solr86:solr'
    # redis: 'redis6:redis'
    # elasticsearch: 'elasticsearch77:elasticsearch'
     mongodb: 'mongodb36:mongodb'

--- a/java/.platform.app.yaml
+++ b/java/.platform.app.yaml
@@ -13,7 +13,7 @@ relationships:
   redis: 'redis6:redis'
   elasticsearch: 'elasticsearch77:elasticsearch'
   memcached: 'memcached16:memcached'
-  solr: 'solr84:solr'
+  solr: 'solr86:solr'
   rabbitmq: 'rabbitmq38:rabbitmq'
   influxdb: 'influxdb18:influxdb'
   kafka: 'kafka25:kafka'

--- a/main/.platform.app.yaml
+++ b/main/.platform.app.yaml
@@ -23,7 +23,7 @@ relationships:
     postgresql: 'postgresql12:postgresql'
     rabbitmq: 'rabbitmq38:rabbitmq'
     redis: 'redis6:redis'
-    solr: 'solr84:solr'
+    solr: 'solr86:solr'
 
 # The size of the persistent disk of the application (in MB).
 disk: 128

--- a/nodejs/.platform.app.yaml
+++ b/nodejs/.platform.app.yaml
@@ -1,5 +1,5 @@
 name: nodejs
-type: nodejs:12
+type: nodejs:14
 
 # The relationships of the application with services or other applications.
 # The left-hand side is the name of the relationship as it will be exposed

--- a/nodejs/.platform.app.yaml
+++ b/nodejs/.platform.app.yaml
@@ -8,7 +8,7 @@ type: nodejs:12
 relationships:
   database: 'mariadb104:mysql'
   postgresql: 'postgresql12:postgresql'
-  solr: 'solr84:solr'
+  solr: 'solr86:solr'
   redis: 'redis6:redis'
   elasticsearch: 'elasticsearch77:elasticsearch'
   mongodb: 'mongodb36:mongodb'

--- a/nodejs/.platform.app.yaml
+++ b/nodejs/.platform.app.yaml
@@ -18,7 +18,7 @@ relationships:
 
 web:
   commands:
-    start: "nodejs index.js"
+    start: "node index.js"
     #in this setup you will find your application stdout and stderr in /app/run/logs
   locations:
     "/public":

--- a/nodejs/enable-local.sh
+++ b/nodejs/enable-local.sh
@@ -3,6 +3,8 @@
 
 platform tunnel:open -e $ENV -A nodejs
 export PLATFORM_RELATIONSHIPS="$(platform tunnel:info -e $ENV -A nodejs --encode)"
+export PLATFORM_ROUTES="$(platform ssh -e $ENV -A nodejs 'echo $PLATFORM_ROUTES' 2&>/dev/null)"
 
-export PLATFORM_APP_NAME=nodejs
+export PLATFORM_APPLICATION_NAME=nodejs
+export PLATFORM_ENVIRONMENT=$ENV
 export PORT=8888

--- a/nodejs/examples/elasticsearch.js
+++ b/nodejs/examples/elasticsearch.js
@@ -1,62 +1,63 @@
-const elasticsearch = require('elasticsearch');
+const elasticsearch = require("elasticsearch");
 const config = require("platformsh-config").config();
 
-exports.usageExample = async function() {
+exports.usageExample = async function () {
+    const credentials = config.credentials("elasticsearch");
 
-    const credentials = config.credentials('elasticsearch');
-
-    var client = new elasticsearch.Client({
+    const client = new elasticsearch.Client({
         host: `${credentials.host}:${credentials.port}`,
     });
 
-
-    let index = 'my_index';
-    let type = 'People';
+    const index = "my_index";
+    const type = "People";
 
     // Index a few document.
-    let names = ['Ada Lovelace', 'Alonzo Church', 'Barbara Liskov'];
+    const names = ["Ada Lovelace", "Alonzo Church", "Barbara Liskov"];
 
-    let message = {
+    const message = {
         refresh: "wait_for",
-        body: []
+        body: names.flatMap((name) => [
+            { index: { _index: index, _type: type } },
+            { name },
+        ]),
     };
-    names.forEach((name) => {
-        message.body.push({index: {_index: index, _type: type}});
-        message.body.push({name: name});
-    });
+
     await client.bulk(message);
 
     // Search for documents.
     const response = await client.search({
-        index: index,
-        q: 'name:Barbara Liskov'
+        index,
+        q: "name:Barbara Liskov",
     });
 
-    let output = '';
-
-    if(response.hits.total.value > 0) {
-        output += `<table>
-        <thead>
-        <tr><th>ID</th><th>Name</th></tr>
-        </thead>
-        <tbody>`;
-        response.hits.hits.forEach((record) => {
-            output += `<tr><td>${record._id}</td><td>${record._source.name}</td></tr>\n`;
-        });
-        output += "</tbody>\n</table>\n";
-    }
-    else {
-        output = "No records found.";
-    }
+    const outputRows = response.hits.hits
+        .map(
+            ({ _id: id, _source: { name } }) =>
+                `<tr><td>${id}</td><td>${name}</td></tr>\n`
+        )
+        .join("\n");
 
     // Clean up after ourselves.
-    response.hits.hits.forEach((record) => {
-        client.delete({
-            index: index,
-            type: type,
-            id: record._id,
-        });
-    });
+    await Promise.allSettled(
+        response.hits.hits.map(({ _id: id }) =>
+            client.delete({
+                index: index,
+                type: type,
+                id,
+            })
+        )
+    );
 
-    return output;
+    return `
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th><th>Name</th>
+            </tr>
+        </thhead>
+        <tbody>
+            ${outputRows}
+        </tbody>
+    </table>
+    `;
 };

--- a/nodejs/examples/memcached.js
+++ b/nodejs/examples/memcached.js
@@ -3,25 +3,21 @@ const config = require("platformsh-config").config();
 const { promisify } = require('util');
 
 exports.usageExample = async function() {
-
     const credentials = config.credentials('memcached');
-
-    let client = new Memcached(`${credentials.host}:${credentials.port}`);
+    const client = new Memcached(`${credentials.host}:${credentials.port}`);
 
     // The MemcacheD client is not Promise-aware, so make it so.
     const memcachedGet = promisify(client.get).bind(client);
     const memcachedSet = promisify(client.set).bind(client);
 
-    let key = 'Deploy-day';
-    let value = 'Friday';
+    const key = 'Deploy-day';
+    const value = 'Friday';
 
     // Set a value.
     await memcachedSet(key, value, 10);
 
     // Read it back.
-    let test = await memcachedGet(key);
+    const test = await memcachedGet(key);
 
-    let output = `Found value <strong>${test}</strong> for key <strong>${key}</strong>.`;
-
-    return output;
+    return `Found value <strong>${test}</strong> for key <strong>${key}</strong>.`;
 };

--- a/nodejs/examples/mongodb.js
+++ b/nodejs/examples/mongodb.js
@@ -1,43 +1,46 @@
-const mongodb = require('mongodb');
+const mongodb = require("mongodb");
 const config = require("platformsh-config").config();
 
-exports.usageExample = async function() {
-    const credentials = config.credentials('mongodb');
+exports.usageExample = async function () {
+    const credentials = config.credentials("mongodb");
     const MongoClient = mongodb.MongoClient;
 
-    var client = await MongoClient.connect(config.formattedCredentials('mongodb', 'mongodb'));
+    const client = await MongoClient.connect(
+        config.formattedCredentials("mongodb", "mongodb")
+    );
 
-    let db = client.db(credentials["path"]);
+    const db = client.db(credentials["path"]);
 
-    let collection = db.collection("startrek");
+    const collection = db.collection("startrek");
 
     const documents = [
-        {'name': 'James Kirk', 'rank': 'Admiral'},
-        {'name': 'Jean-Luc Picard', 'rank': 'Captain'},
-        {'name': 'Benjamin Sisko', 'rank': 'Prophet'},
-        {'name': 'Katheryn Janeway', 'rank': 'Captain'},
+        { name: "James Kirk", rank: "Admiral" },
+        { name: "Jean-Luc Picard", rank: "Captain" },
+        { name: "Benjamin Sisko", rank: "Prophet" },
+        { name: "Katheryn Janeway", rank: "Captain" },
     ];
 
-    await collection.insertMany(documents, {w: 1});
+    await collection.insertMany(documents, { w: 1 });
 
-    let result = await collection.find({rank:"Captain"}).toArray();
+    const result = await collection.find({ rank: "Captain" }).toArray();
 
-    let output = '';
-
-    output += `<table>
-<thead>
-<tr><th>Name</th><th>Rank</th></tr>
-</thead>
-<tbody>`;
-
-    Object.keys(result).forEach((key) => {
-        output += `<tr><td>${result[key].name}</td><td>${result[key].rank}</td></tr>\n`;
-    });
-
-    output += `</tbody>\n</table>\n`;
+    const outputRows = Object.values(result)
+        .map(({ name, rank }) => `<tr><td>${name}</td><td>${rank}</td></tr>\n`)
+        .join("\n");
 
     // Clean up after ourselves.
     collection.deleteMany();
 
-    return output;
+    return `
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th><th>Rank</th>
+            </tr>
+        </thhead>
+        <tbody>
+            ${outputRows}
+        </tbody>
+    </table>
+    `;
 };

--- a/nodejs/examples/mysql.js
+++ b/nodejs/examples/mysql.js
@@ -1,9 +1,8 @@
-const mysql = require('mysql2/promise');
+const mysql = require("mysql2/promise");
 const config = require("platformsh-config").config();
 
-exports.usageExample = async function() {
-
-    const credentials = config.credentials('database');
+exports.usageExample = async function () {
+    const credentials = config.credentials("database");
 
     const connection = await mysql.createConnection({
         host: credentials.host,
@@ -13,46 +12,44 @@ exports.usageExample = async function() {
         database: credentials.path,
     });
 
-    let sql = '';
-
     // Creating a table.
-    sql = `CREATE TABLE IF NOT EXISTS People (
-        id INT(6) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    await connection.query(
+        `CREATE TABLE IF NOT EXISTS People (
+            id INT(6) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
             name VARCHAR(30) NOT NULL,
             city VARCHAR(30) NOT NULL
-        )`;
-    await connection.query(sql);
+        )`
+    );
 
     // Insert data.
-    sql = `INSERT INTO People (name, city) VALUES
-    ('Neil Armstrong', 'Moon'),
-        ('Buzz Aldrin', 'Glen Ridge'),
-        ('Sally Ride', 'La Jolla');`;
-    await connection.query(sql);
+    await connection.query(
+        `INSERT INTO People (name, city)
+        VALUES
+            ('Neil Armstrong', 'Moon'),
+            ('Buzz Aldrin', 'Glen Ridge'),
+            ('Sally Ride', 'La Jolla');`
+    );
 
     // Show table.
-    sql = `SELECT * FROM People`;
-    let [rows] = await connection.query(sql);
-
-    let output = '';
-
-    if (rows.length > 0) {
-        output +=`<table>
-            <thead>
-            <tr><th>Name</th><th>City</th></tr>
-            </thead>
-            <tbody>`;
-
-        rows.forEach((row) => {
-            output += `<tr><td>${row.name}</td><td>${row.city}</td></tr>\n`;
-        });
-
-        output += `</tbody>\n</table>\n`;
-    }
+    const [rows] = await connection.query("SELECT * FROM People");
 
     // Drop table.
-    sql = `DROP TABLE People`;
-    await connection.query(sql);
+    await connection.query("DROP TABLE People");
 
-    return output;
+    const outputRows = rows
+        .map(({ name, city }) => `<tr><td>${name}</td><td>${city}</td></tr>\n`)
+        .join("\n");
+
+    return `
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th><th>City</th>
+            </tr>
+        </thhead>
+        <tbody>
+            ${outputRows}
+        </tbody>
+    </table>
+    `;
 };

--- a/nodejs/examples/postgresql.js
+++ b/nodejs/examples/postgresql.js
@@ -1,9 +1,8 @@
-const pg = require('pg');
+const pg = require("pg");
 const config = require("platformsh-config").config();
 
-exports.usageExample = async function() {
-
-    const credentials = config.credentials('postgresql');
+exports.usageExample = async function () {
+    const credentials = config.credentials("postgresql");
 
     const client = new pg.Client({
         host: credentials.host,
@@ -15,46 +14,44 @@ exports.usageExample = async function() {
 
     client.connect();
 
-    let sql = '';
-
     // Creating a table.
-    sql = `CREATE TABLE IF NOT EXISTS People (
-      id SERIAL PRIMARY KEY,
-      name VARCHAR(30) NOT NULL,
-      city VARCHAR(30) NOT NULL
-      )`;
-    await client.query(sql);
+    await client.query(
+        `CREATE TABLE IF NOT EXISTS People (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(30) NOT NULL,
+            city VARCHAR(30) NOT NULL
+        )`
+    );
 
     // Insert data.
-    sql = `INSERT INTO People (name, city) VALUES 
-        ('Neil Armstrong', 'Moon'), 
-        ('Buzz Aldrin', 'Glen Ridge'), 
-        ('Sally Ride', 'La Jolla');`;
-    await client.query(sql);
+    await client.query(
+        `INSERT INTO People (name, city)
+        VALUES
+            ('Neil Armstrong', 'Moon'),
+            ('Buzz Aldrin', 'Glen Ridge'),
+            ('Sally Ride', 'La Jolla');`
+    );
 
     // Show table.
-    sql = `SELECT * FROM People`;
-    let result = await client.query(sql);
-
-    let output = '';
-
-    if (result.rows.length > 0) {
-        output +=`<table>
-            <thead>
-            <tr><th>Name</th><th>City</th></tr>
-            </thead>
-            <tbody>`;
-
-        result.rows.forEach((row) => {
-            output += `<tr><td>${row.name}</td><td>${row.city}</td></tr>\n`;
-        });
-
-        output += `</tbody>\n</table>\n`;
-    }
+    const result = await client.query("SELECT * FROM People");
 
     // Drop table.
-    sql = `DROP TABLE People`;
-    await client.query(sql);
+    await client.query("DROP TABLE People");
 
-    return output;
+    const outputRows = result.rows
+        .map(({ name, city }) => `<tr><td>${name}</td><td>${city}</td></tr>\n`)
+        .join("\n");
+
+    return `
+    <table>
+        <thead>
+            <tr>
+                <th>Name</th><th>City</th>
+            </tr>
+        </thhead>
+        <tbody>
+            ${outputRows}
+        </tbody>
+    </table>
+    `;
 };

--- a/nodejs/examples/redis.js
+++ b/nodejs/examples/redis.js
@@ -3,25 +3,21 @@ const config = require("platformsh-config").config();
 const { promisify } = require('util');
 
 exports.usageExample = async function() {
-
     const credentials = config.credentials('redis');
-
-    var client = redis.createClient(credentials.port, credentials.host);
+    const client = redis.createClient(credentials.port, credentials.host);
 
     // The Redis client is not Promise-aware, so make it so.
     const redisGet = promisify(client.get).bind(client);
     const redisSet = promisify(client.set).bind(client);
 
-    let key = 'Deploy day';
-    let value = 'Friday';
+    const key = 'Deploy day';
+    const value = 'Friday';
 
     // Set a value.
     await redisSet(key, value);
 
     // Read it back.
-    let test = await redisGet(key);
+    const test = await redisGet(key);
 
-    let output = `Found value <strong>${test}</strong> for key <strong>${key}</strong>.`;
-
-    return output;
+    return `Found value <strong>${test}</strong> for key <strong>${key}</strong>.`;
 };

--- a/nodejs/examples/solr.js
+++ b/nodejs/examples/solr.js
@@ -1,31 +1,28 @@
-const solr = require('solr-node');
+const solr = require("solr-node");
 const config = require("platformsh-config").config();
 
-exports.usageExample = async function() {
-
-    let client = new solr(config.formattedCredentials('solr', 'solr-node'));
-
-    let output = '';
+exports.usageExample = async function () {
+    const client = new solr(config.formattedCredentials("solr", "solr-node"));
 
     // Add a document.
-    let addResult = await client.update({
+    const addResult = await client.update({
         id: 123,
-        name: 'Valentina Tereshkova',
+        name: "Valentina Tereshkova",
     });
-
-    output += "Adding one document. Status (0 is success): " + addResult.responseHeader.status +  "<br />\n";
 
     // Flush writes so that we can query against them.
     await client.softCommit();
 
     // Select one document:
-    let strQuery = client.query().q();
-    let writeResult = await client.search(strQuery);
-    output += "Selecting documents (1 expected): " + writeResult.response.numFound + "<br />\n";
+    const strQuery = client.query().q();
+    const writeResult = await client.search(strQuery);
 
     // Delete one document.
-    let deleteResult = await client.delete({id: 123});
-    output += "Deleting one document. Status (0 is success): " + deleteResult.responseHeader.status + "<br />\n";
+    const deleteResult = await client.delete({ id: 123 });
 
-    return output;
+    return `
+    Adding one document. Status (0 is success): ${addResult.responseHeader.status}<br />
+    Selecting documents (1 expected): ${writeResult.response.numFound}<br />
+    Deleting one document. Status (0 is success): ${deleteResult.responseHeader.status}<br />
+    `;
 };

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -1,34 +1,37 @@
-const express = require('express');
-const parseUrl = require('parse_url');
-const platformsh = require('platformsh-config');
+const parseUrl = require("parse_url");
+const platformsh = require("platformsh-config");
+const express = require("express");
 
-let config = platformsh.config();
+const config = platformsh.config();
 
-var app = express();
-
-// Set up a base path for routes based on the Route definition.
-let basePath = '/';
-if (config.isValidPlatform()) {
-    const platformRoute = config.getRoute('nodejs');
-    basePath = '/' + (parseUrl(platformRoute['url'])[5] || '');
+// Exit if the running environment doesn't have everything needed.
+// @see enable-local.sh for local dev.
+if (!config.isValidPlatform()) {
+    console.error("The app isn't running in a PSH environment. Source the enable-local.sh file for local dev.");
+    process.exit(-1);
 }
 
-app.use(basePath, require('./routes'));
+// Set up a base path for routes based on the Route definition.
+const platformRoute = config.getRoute("nodejs");
+const basePath = "/" + (parseUrl(platformRoute["url"])[5] || "");
 
-app.use(function(req, res, next){
+const app = express();
+
+app.use(basePath, require("./routes"));
+
+app.use(function (req, res, next) {
     res.status(404);
 
     // Respond with JSON.
-    if (req.accepts('json')) {
-        res.send({ error: 'Sorry, no sample code is available.' });
-        return;
+    if (req.accepts("json")) {
+        return res.send({ error: "Sorry, no sample code is available." });
     }
 
     // Default to plain-text.
-    res.type('txt').send('Sorry, no sample code is available.');
+    return res.type("txt").send("Sorry, no sample code is available.");
 });
 
 // Start the server.
-app.listen(config.port, function() {
+app.listen(config.port, function () {
     console.log(`Listening on port ${config.port}`);
 });

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -4,23 +4,10 @@ const platformsh = require('platformsh-config');
 
 let config = platformsh.config();
 
-if (process.env.NODE_ENV === 'test') {
-
-    config = {
-        applicationName: 'test',
-        port: 8080,
-        getRoute: (id) => {
-            return {url: 'http://localhost/nodejs'}
-        }
-    };
-}
-else {
-}
-
 var app = express();
 
 // Set up a base path for routes based on the Route definition.
-let basePath = '';
+let basePath = '/';
 if (config.isValidPlatform()) {
     const platformRoute = config.getRoute('nodejs');
     basePath = '/' + (parseUrl(platformRoute['url'])[5] || '');

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -56,23 +56,26 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
     "base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
       }
     },
     "bluebird": {
@@ -110,12 +113,12 @@
       "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
     },
     "buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-writer": {
@@ -139,19 +142,6 @@
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
       }
-    },
-    "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
-    "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "connection-parse": {
       "version": "0.0.7",
@@ -181,23 +171,10 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
-    "cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "crc": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
-      "requires": {
-        "buffer": "^5.1.0"
-      }
     },
     "debug": {
       "version": "2.6.9",
@@ -214,11 +191,6 @@
         }
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
     "denque": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
@@ -234,20 +206,15 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
-    "double-ended-queue": {
-      "version": "2.1.0-0",
-      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elasticsearch": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-15.5.0.tgz",
-      "integrity": "sha512-ZGKKaDkOFAap61ObBNkAxhYXCcAbRfkI4NVoSeLGnTD6/cItvY2j9LII/VV8/zclGe1x5m6DsVp47E4ze4aAeQ==",
+      "version": "16.7.1",
+      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-16.7.1.tgz",
+      "integrity": "sha512-PL/BxB03VGbbghJwISYvVcrR9KbSSkuQ7OM//jHJg/End/uC2fvXg4QI7RXLvCGbhBuNQ8dPue7DOOPra73PCw==",
       "requires": {
         "agentkeepalive": "^3.4.1",
         "chalk": "^1.0.0",
@@ -318,11 +285,6 @@
         }
       }
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -336,21 +298,6 @@
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
       }
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
-    "formidable": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -416,42 +363,14 @@
       }
     },
     "ieee754": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
-    "influx-ql": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/influx-ql/-/influx-ql-2.9.0.tgz",
-      "integrity": "sha512-hT8fgTl+YFhx3PRoLISRqjUVGN1nxRdO8mghW16O5Jj2oLhH+giA+pDlloKyC6QxNXRFaNtCQpxqxXsVSysSJA=="
-    },
-    "influxdb-nodejs": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/influxdb-nodejs/-/influxdb-nodejs-2.11.0.tgz",
-      "integrity": "sha512-/Wyl5TtLNlTwjZBvr2b6HuobgImyILCSm/Zdh+3a7ZnZx449Gv0UQaBby+Z4IAKsBNeOJGwWGMChWrA5L9Zkvg==",
-      "requires": {
-        "debug": "^3.1.0",
-        "influx-ql": "^2.9.0",
-        "lodash": "^4.17.10",
-        "nano-seconds": "^1.2.2",
-        "superagent": "^3.8.3",
-        "superagent-load-balancer": "^2.0.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        }
-      }
+    "influx": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/influx/-/influx-5.6.3.tgz",
+      "integrity": "sha512-j2biV776HXb2IbIcp2G24w50IqIWENDnKitm0Vj54vlpw9EfGzY7x7ndCRZSGzzm4fyDLSDQ+/cypZQpuDQxyA=="
     },
     "inherits": {
       "version": "2.0.3",
@@ -487,9 +406,9 @@
       "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "long": {
       "version": "4.0.0",
@@ -497,11 +416,11 @@
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
-        "yallist": "^3.0.2"
+        "yallist": "^4.0.0"
       }
     },
     "media-typer": {
@@ -534,30 +453,12 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
-    "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
-    },
-    "mime-db": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
-    },
-    "mime-types": {
-      "version": "2.1.22",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
-      "requires": {
-        "mime-db": "~1.38.0"
-      }
-    },
     "mongodb": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.1.tgz",
-      "integrity": "sha512-uH76Zzr5wPptnjEKJRQnwTsomtFOU/kQEU8a9hKHr2M7y9qVk7Q4Pkv0EQVp88742z9+RwvsdTw6dRjDZCNu1g==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
+      "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
       "requires": {
-        "bl": "^2.2.0",
+        "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
         "require_optional": "^1.0.1",
@@ -573,17 +474,39 @@
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
           }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         }
       }
     },
     "mongoose": {
-      "version": "5.10.2",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.10.2.tgz",
-      "integrity": "sha512-VO5eZawEMFh2gx9XPg9ZafzFg5eIVs4R7PW6kK1MFqBq34YD7GomkalYWVt02HctvTPDI1mkXsm52LXNZR1NxA==",
+      "version": "5.10.12",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.10.12.tgz",
+      "integrity": "sha512-BoWagkWYEfpNCBPzSbfTlLHEtiGziSXbH/YHibrZbhvH1t+zM98X/guL7Ieeh35el4ilf+XFruK84nF5k0QpSw==",
       "requires": {
         "bson": "^1.1.4",
         "kareem": "2.3.1",
-        "mongodb": "3.6.0",
+        "mongodb": "3.6.2",
         "mongoose-legacy-pluralize": "1.0.2",
         "mpath": "0.7.0",
         "mquery": "3.2.2",
@@ -594,17 +517,12 @@
         "sliced": "1.0.1"
       },
       "dependencies": {
-        "bson": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
-        },
         "mongodb": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.0.tgz",
-          "integrity": "sha512-/XWWub1mHZVoqEsUppE0GV7u9kanLvHxho6EvBxQbShXTKYF9trhZC2NzbulRGeG7xMJHD8IOWRcdKx5LPjAjQ==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.2.tgz",
+          "integrity": "sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==",
           "requires": {
-            "bl": "^2.2.0",
+            "bl": "^2.2.1",
             "bson": "^1.1.4",
             "denque": "^1.4.1",
             "require_optional": "^1.0.1",
@@ -623,10 +541,46 @@
             }
           }
         },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        },
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
         }
       }
     },
@@ -673,26 +627,26 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mysql2": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-1.7.0.tgz",
-      "integrity": "sha512-xTWWQPjP5rcrceZQ7CSTKR/4XIDeH/cRkNH/uzvVGQ7W5c7EJ0dXeJUusk7OKhIoHj7uFKUxDVSCfLIl+jluog==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.2.5.tgz",
+      "integrity": "sha512-XRqPNxcZTpmFdXbJqb+/CtYVLCx14x1RTeNMD4954L331APu75IC74GDqnZMEt1kwaXy6TySo55rF2F3YJS78g==",
       "requires": {
         "denque": "^1.4.1",
         "generate-function": "^2.3.1",
-        "iconv-lite": "^0.5.0",
+        "iconv-lite": "^0.6.2",
         "long": "^4.0.0",
-        "lru-cache": "^5.1.1",
+        "lru-cache": "^6.0.0",
         "named-placeholders": "^1.1.2",
         "seq-queue": "^0.0.5",
-        "sqlstring": "^2.3.1"
+        "sqlstring": "^2.3.2"
       },
       "dependencies": {
         "iconv-lite": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.0.tgz",
-          "integrity": "sha512-NnEhI9hIEKHOzJ4f697DMz9IQEXr/MMJ5w64vN2/4Ai+wRnvV7SBrL0KLoRlwaKVghOc7LQ5YkPLuX146b6Ydw==",
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         }
       }
@@ -720,11 +674,6 @@
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         }
       }
-    },
-    "nano-seconds": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/nano-seconds/-/nano-seconds-1.2.2.tgz",
-      "integrity": "sha512-s06EY41x1hM6BJE2HhIFRzvXuVUlZNd4761lduv+hjgtDDR7W4RzhShkap2wJcWMO6+CahR+49cCQJfFmgf7gw=="
     },
     "negotiator": {
       "version": "0.6.2",
@@ -765,46 +714,38 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "pg": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.2.tgz",
-      "integrity": "sha512-Mvt0dGYMwvEADNKy5PMQGlzPudKcKKzJds/VbOeZJpb6f/pI3mmoXX0JksPgI3l3JPP/2Apq7F36O63J7mgveA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.4.2.tgz",
+      "integrity": "sha512-E9FlUrrc7w3+sbRmL1CSw99vifACzB2TjhMM9J5w9D1LIg+6un0jKkpHS1EQf2CWhKhec2bhrBLVMmUBDbjPRQ==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "0.1.3",
-        "pg-packet-stream": "^1.1.0",
-        "pg-pool": "^2.0.10",
+        "pg-connection-string": "^2.4.0",
+        "pg-pool": "^3.2.2",
+        "pg-protocol": "^1.3.0",
         "pg-types": "^2.1.0",
-        "pgpass": "1.x",
-        "semver": "4.3.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
-          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
-        }
+        "pgpass": "1.x"
       }
     },
     "pg-connection-string": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
-      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
+      "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
     },
     "pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
-    "pg-packet-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
-      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
-    },
     "pg-pool": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
-      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.2.tgz",
+      "integrity": "sha512-ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA=="
+    },
+    "pg-protocol": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.3.0.tgz",
+      "integrity": "sha512-64/bYByMrhWULUaCd+6/72c9PMWhiVFs3EVxl9Ct6a3v/U8+rKgqP2w+kKg/BIGgMJyB+Bk/eNivT32Al+Jghw=="
     },
     "pg-types": {
       "version": "2.2.0",
@@ -819,11 +760,11 @@
       }
     },
     "pgpass": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
-      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
+      "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
       "requires": {
-        "split": "^1.0.0"
+        "split2": "^3.1.1"
       }
     },
     "platformsh-config": {
@@ -842,9 +783,9 @@
       "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
     },
     "postgres-date": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.5.tgz",
-      "integrity": "sha512-pdau6GRPERdAYUQwkBnGKxEfPyhVZXG/JiS44iZWiNdSOWE09N2lUgN6yshuq6fVSon4Pm0VMXd1srUUkLe9iA=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
     },
     "postgres-interval": {
       "version": "1.2.0",
@@ -873,11 +814,6 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -895,38 +831,43 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "redis": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.0.2.tgz",
+      "integrity": "sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==",
       "requires": {
-        "double-ended-queue": "^2.1.0-0",
-        "redis-commands": "^1.2.0",
-        "redis-parser": "^2.6.0"
+        "denque": "^1.4.1",
+        "redis-commands": "^1.5.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
       }
     },
     "redis-commands": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.4.0.tgz",
-      "integrity": "sha512-cu8EF+MtkwI4DLIT0x9P8qNTLFhQD4jLfxLR0cCNkeGzs87FN6879JOJwNQR/1zD7aSYNbU0hgsV9zGY71Itvw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.6.0.tgz",
+      "integrity": "sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
     },
     "redis-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
     },
     "regexp-clone": {
       "version": "1.0.0",
@@ -972,9 +913,9 @@
       }
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "send": {
       "version": "0.17.1",
@@ -1063,18 +1004,18 @@
         "memory-pager": "^1.0.2"
       }
     },
-    "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+    "split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "requires": {
-        "through": "2"
+        "readable-stream": "^3.0.0"
       }
     },
     "sqlstring": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
-      "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.2.tgz",
+      "integrity": "sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg=="
     },
     "statuses": {
       "version": "1.5.0",
@@ -1082,11 +1023,18 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
       }
     },
     "strip-ansi": {
@@ -1097,82 +1045,10 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "superagent": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
-      "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "superagent-load-balancer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/superagent-load-balancer/-/superagent-load-balancer-2.0.3.tgz",
-      "integrity": "sha1-7AflmTnjTW1q4Ig0se/alx0c6OI=",
-      "requires": {
-        "crc": "^3.4.4"
-      }
-    },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "toidentifier": {
       "version": "1.0.0",
@@ -1234,9 +1110,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yallist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -8,18 +8,18 @@
   },
   "license": "MIT",
   "dependencies": {
-    "bl": "^2.2.1",
-    "elasticsearch": "^15.5.0",
+    "bl": "^4.0.3",
+    "elasticsearch": "^16.7.1",
     "express": "^4.17.1",
     "influxdb-nodejs": "^2.11.0",
     "memcached": "^2.2.2",
-    "mongodb": "^3.6.1",
-    "mongoose": "^5.10.2",
-    "mysql2": "^1.7.0",
+    "mongodb": "^3.6.3",
+    "mongoose": "^5.10.12",
+    "mysql2": "^2.2.5",
     "parse_url": "^0.1.1",
-    "pg": "^7.18.2",
+    "pg": "^8.4.2",
     "platformsh-config": "^2.3.1",
-    "redis": "^2.8.0",
+    "redis": "^3.0.2",
     "solr-node": "^1.2.1"
   }
 }

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -11,7 +11,7 @@
     "bl": "^4.0.3",
     "elasticsearch": "^16.7.1",
     "express": "^4.17.1",
-    "influxdb-nodejs": "^2.11.0",
+    "influx": "^5.6.3",
     "memcached": "^2.2.2",
     "mongodb": "^3.6.3",
     "mongoose": "^5.10.12",

--- a/nodejs/routes.js
+++ b/nodejs/routes.js
@@ -6,7 +6,7 @@ var data = {};
 
 let services = {
     elasticsearch: 'Elasticsearch',
-    // influxdb: 'InfluxDB',
+    influxdb: 'InfluxDB',
     memcached: 'Memcached',
     mongodb: 'MongoDB',
     mysql: 'MySQL',

--- a/nodejs/routes.js
+++ b/nodejs/routes.js
@@ -31,26 +31,21 @@ function escapeHtml(s) {
 
 // Call all of the run() methods of all services, and store their output once.
 async function runData(key) {
-    let value = undefined;
     try{
         const method = data[key].usageExample;
-        value = await method();
+        const value = await method();
+        if (value) {
+            data[key].output = value;
+        }
+        return Promise.resolve();
     } catch (err) {
         console.error(err);
     }
-    if (value) {
-        data[key].output = value;
-    }
 }
 
-// array of Promise<void>
-const promises = Object.keys(data).map(runData);
-
-
 async function index(req, res) {
-
     try {
-        await Promise.all(promises);
+        await Promise.all(Object.keys(data).map(runData));
     }
     catch (error) {
         console.error(error);
@@ -94,17 +89,16 @@ async function index(req, res) {
 <h1>Service examples for Node.js</h1>
 `);
 
-    Object.keys(data).forEach ((key) => {
-        let name = key;
+    Object.values(data).forEach (({label, source, output}) => {
         res.write(`<details>
-      <summary>${data[key].label} Sample Code</summary>
+      <summary>${label} Sample Code</summary>
       <section>
       <h3>Source</h3>
-      <pre>${data[key].source}</pre>
+      <pre>${source}</pre>
       </section>
       <section>
       <h3>Output</h3>
-      ${data[key].output}
+      ${output}
       </section>
       </details>
       `);

--- a/php/.platform.app.yaml
+++ b/php/.platform.app.yaml
@@ -32,7 +32,7 @@ hooks:
 relationships:
     database: 'mariadb104:mysql'
     postgresql: 'postgresql12:postgresql'
-    solr: 'solr84:solr'
+    solr: 'solr86:solr'
     redis: 'redis6:redis'
     elasticsearch: 'elasticsearch77:elasticsearch'
     mongodb: 'mongodb36:mongodb'

--- a/python/.platform.app.yaml
+++ b/python/.platform.app.yaml
@@ -29,7 +29,7 @@ disk: 1024
 relationships:
     database: 'mariadb104:mysql'
     postgresql: 'postgresql12:postgresql'
-    solr: 'solr84:solr'
+    solr: 'solr86:solr'
     redis: 'redis6:redis'
     elasticsearch: 'elasticsearch77:elasticsearch'
     mongodb: 'mongodb36:mongodb'


### PR DESCRIPTION
## Changes:

### Node specific
- Use `node:14` image instead of 12
- Update dependencies
- Use a more maintained influxdb lib
- Add env var to `enable-local.sh` for local dev and remove dev specific code in `index.js`

### Global
- Use `solr:8.6` instead of 8.4

## What it fixes
- Postgres requests were pending forever when using node:14. This was because our version of `pg` (postgres-node) didn't support node 14 (as every versions <= 8.0.2).
- `solr:8.4` was throwing `ECONREFUSED` errors when using `node:14`. `solr:8.6` seems to work fine.

## Refactor
- More idiomatic JS code.

## InfluxDB

The Node.js InfluxDB works, theoretically...
Our current InfluxDB image doesn't have a default user. Since we have `auth-enabled = true` in our InfluxDB configuration, the behaviour in such cases is that Influx allows for only one type of unauthorised requests: the one to create an admin user. If you then delete this user and end up in a situation where you don't have any users anymore (which is what happens with our PHP example for instance), then you're locked out of the database, as influx won't allow any unauthorised requests anymore.
The Node.js example takes this into account and uses a default `admin`/`admin` for now if there's no username and password in our PSH env vars.
[This MR](https://lab.plat.farm/images/influxdb/-/merge_requests/20) will make things easier. Once this is merged, the code for InfluxDB examples will be adapted and more will be added.