### PR TITLE
fix: backtick processing

### DIFF
--- a/golang/examples/mysql.go
+++ b/golang/examples/mysql.go
@@ -3,6 +3,7 @@ package examples
 import (
 	"database/sql"
 	"fmt"
+
 	_ "github.com/go-sql-driver/mysql"
 	psh "github.com/platformsh/config-reader-go/v2"
 	sqldsn "github.com/platformsh/config-reader-go/v2/sqldsn"
@@ -31,35 +32,33 @@ func UsageExampleMySQL() string {
 
 	// Force MySQL into modern mode.
 	db.Exec("SET NAMES=utf8")
-	db.Exec(`SET sql_mode = 'ANSI,STRICT_TRANS_TABLES,STRICT_ALL_TABLES,
-    NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,
-    NO_AUTO_CREATE_USER,ONLY_FULL_GROUP_BY'`)
+	db.Exec("SET sql_mode = 'ANSI,STRICT_TRANS_TABLES,STRICT_ALL_TABLES," +
+		"NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO," +
+		"NO_AUTO_CREATE_USER,ONLY_FULL_GROUP_BY'")
 
 	// Creating a table.
-	sqlCreate := `
-CREATE TABLE IF NOT EXISTS People (
-id INT(6) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-name VARCHAR(30) NOT NULL,
-city VARCHAR(30) NOT NULL)`
+	sqlCreate := "CREATE TABLE IF NOT EXISTS People (" +
+		"id INT(6) UNSIGNED AUTO_INCREMENT PRIMARY KEY," +
+		"name VARCHAR(30) NOT NULL," +
+		"city VARCHAR(30) NOT NULL)"
 
 	_, err = db.Exec(sqlCreate)
 	checkErr(err)
 
 	// Insert data.
-	sqlInsert := `
-INSERT INTO People (name, city) VALUES
-('Neil Armstrong', 'Moon'),
-('Buzz Aldrin', 'Glen Ridge'),
-('Sally Ride', 'La Jolla');`
+	sqlInsert := "INSERT INTO People (name, city) VALUES" +
+		"('Neil Armstrong', 'Moon')," +
+		"('Buzz Aldrin', 'Glen Ridge')," +
+		"('Sally Ride', 'La Jolla');"
 
 	_, err = db.Exec(sqlInsert)
 	checkErr(err)
 
-	table := `<table>
-<thead>
-<tr><th>Name</th><th>City</th></tr>
-</thead>
-<tbody>`
+	table := "<table>" +
+		"<thead>" +
+		"<tr><th>Name</th><th>City</th></tr>" +
+		"</thead>" +
+		"<tbody>"
 
 	var id int
 	var name string

--- a/golang/examples/postgresql.go
+++ b/golang/examples/postgresql.go
@@ -3,6 +3,7 @@ package examples
 import (
 	"database/sql"
 	"fmt"
+
 	_ "github.com/lib/pq"
 	psh "github.com/platformsh/config-reader-go/v2"
 	libpq "github.com/platformsh/config-reader-go/v2/libpq"
@@ -31,30 +32,28 @@ func UsageExamplePostgreSQL() string {
 	defer db.Close()
 
 	// Creating a table.
-	sqlCreate := `
-CREATE TABLE IF NOT EXISTS PeopleGo (
-id SERIAL PRIMARY KEY,
-name VARCHAR(30) NOT NULL,
-city VARCHAR(30) NOT NULL);`
+	sqlCreate := "CREATE TABLE IF NOT EXISTS PeopleGo (" +
+		"id SERIAL PRIMARY KEY," +
+		"name VARCHAR(30) NOT NULL," +
+		"city VARCHAR(30) NOT NULL);"
 
 	_, err = db.Exec(sqlCreate)
 	checkErr(err)
 
 	// Insert data.
-	sqlInsert := `
-INSERT INTO PeopleGo(name, city) VALUES
-('Neil Armstrong', 'Moon'),
-('Buzz Aldrin', 'Glen Ridge'),
-('Sally Ride', 'La Jolla');`
+	sqlInsert := "INSERT INTO PeopleGo(name, city) VALUES" +
+		"('Neil Armstrong', 'Moon')," +
+		"('Buzz Aldrin', 'Glen Ridge')," +
+		"('Sally Ride', 'La Jolla');"
 
 	_, err = db.Exec(sqlInsert)
 	checkErr(err)
 
-	table := `<table>
-<thead>
-<tr><th>Name</th><th>City</th></tr>
-</thead>
-<tbody>`
+	table := "<table>" +
+		"<thead>" +
+		"<tr><th>Name</th><th>City</th></tr>" +
+		"</thead>" +
+		"<tbody>"
 
 	var id int
 	var name string

--- a/golang/examples/solr.go
+++ b/golang/examples/solr.go
@@ -2,6 +2,7 @@ package examples
 
 import (
 	"fmt"
+
 	psh "github.com/platformsh/config-reader-go/v2"
 	gosolr "github.com/platformsh/config-reader-go/v2/gosolr"
 	solr "github.com/rtt/Go-Solr"
@@ -55,10 +56,10 @@ func UsageExampleSolr() string {
 	resDel, err := connection.Update(docDelete, true)
 	checkErr(err)
 
-	message := fmt.Sprintf(`Adding one document - %s<br>
-Selecting document (1 expected): %d<br>
-Deleting document - %s<br>
-  `, respAdd, resSelect.Results.NumFound, resDel)
+	message := fmt.Sprintf("Adding one document - %s<br>"+
+		"Selecting document (1 expected): %d<br>"+
+		"Deleting document - %s<br>",
+		respAdd, resSelect.Results.NumFound, resDel)
 
 	return message
 }


### PR DESCRIPTION
The current source generation produces hex encoded backticks, resulting in invalid code.

There seems to be no way to properly encode or escape them, as the final code is itself part of a backticked multi-lines string.

Go does not allow nesting or escaping backticks. There's some proposals to address this issue:
- https://github.com/golang/go/issues/32190
- https://github.com/golang/go/issues/32590

but look like nothing got accepted there yet.

The current sources have been updated to use string concatenation instead of backticks, and the generator got updated to panic if it encounter any.

This is not an ideal solution, as some sources may require the usage of backticks at some point, but it would probably require a deeper rework of the generation to fix it (maybe external files + go:embed ?)